### PR TITLE
Update rpicam.1

### DIFF
--- a/etc/nginx/sites-available/rpicam.1
+++ b/etc/nginx/sites-available/rpicam.1
@@ -1,7 +1,7 @@
 server {
 	listen   80;
 
-	root /var/www;
+	root /var/www/html;
 	index index.php index.html index.htm;
 	server_name localhost;
 


### PR DESCRIPTION
html folder is missing, leads to 403 error messages in nginx.
Perhaps you have an variable for the given subdirectory then it should be used here
